### PR TITLE
Clean up main title IDs, change font to be non-italic and bold

### DIFF
--- a/static-dev/js/main.js
+++ b/static-dev/js/main.js
@@ -1,10 +1,10 @@
 $(document).ready(function(){
 	// Initialise typed text.
-	var typed = new Typed('#subtitle', {
+	var typed = new Typed('#main-title-container', {
 		onComplete: function(self) {
 			$('.typed-cursor').fadeOut();
 		},
-		stringsElement: '#subtitle-strings',
+		stringsElement: '#main-title-strings',
 		typeSpeed: 30
 	});
 

--- a/static-dev/sass/_head.scss
+++ b/static-dev/sass/_head.scss
@@ -43,41 +43,47 @@
 div.area-index-header {
   padding-top: 0;
 
-  #subtitle-strings {
-    display: none;
-  }
-
-  #subtitle,
-  .typed-cursor {
-    font: {
-      family: $main-font;
-      size: 3em;
-      style: italic;
-      weight: 200;
+  #main-title {
+    #main-title-strings {
+      display: none;
     }
-  }
 
-  #subtitle {
-    margin: 0 -3px 30px -3px;
-    overflow: visible;
-
-    span {
-      padding: {
-        left: 5px;
-        right: 10px;
+    #main-title-container,
+    .typed-cursor {
+      font: {
+        family: $main-font;
+        size: ($main-text-size * 2.8);
+        weight: 700;
       }
     }
 
-    span.hl-1 {
-      background: #8df472;
-    }
+    #main-title-container {
+      margin: 0 -3px 30px -3px;
+      overflow: visible;
+      line-height: 1.5;
 
-    span.hl-2 {
-      background: #8ee3fc;
-    }
+      span {
+        padding: {
+          left: 7px;
+          right: 7px;
+          top: 3px;
+          bottom: 3px;
+        }
 
-    span.hl-3 {
-      background: #ba95fe;
+        margin-left: -4px;
+      }
+
+      span.hl-1 {
+        background: #8df472;
+      }
+
+      span.hl-2 {
+        background: #8ee3fc;
+      }
+
+      span.hl-3 {
+        background: #b6adf9;
+      }
     }
   }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,8 +8,10 @@
 	<div class="container-fluid">
 		<div class="row justify-content-center area area-index-header">
 			<div class="col">
-				<span id="subtitle-strings"><p>{% blocktrans %}We want a Europe where <span class="hl-1">sharing</span>, <span class="hl-2">innovation</span> and <span class="hl-3">copyright</span> go hand in hand.{% endblocktrans %}</p></span>
-				<span id="subtitle"></span>
+				<h1 id="main-title">
+					<span id="main-title-strings"><p>{% blocktrans %}We want a Europe where <span class="hl-1">sharing</span>, <span class="hl-2">innovation</span> and <span class="hl-3">copyright</span> go hand in hand.{% endblocktrans %}</p></span>
+					<span id="main-title-container"></span>
+				</h1>
 			</div>
 		</div>
 		<div class="row justify-content-center area area-index-header">


### PR DESCRIPTION
I quite liked the italic/light combo that was there before, but I don't think it really works as a main title in big size. So I'd change the main title to this and instead make some of the subheadlines below italic & light.

![2017-08-03-19 17 23](https://user-images.githubusercontent.com/179393/28934320-d1c070e8-7880-11e7-8aed-e66b7229c531.png)
