### PR TITLE
Add green background to header/navigation area and adjust main highlights

### DIFF
--- a/static-dev/sass/_head.scss
+++ b/static-dev/sass/_head.scss
@@ -39,6 +39,26 @@
   }
 }
 
+#index-background-container {
+  // Needed to make the absolute positioning below reference this div.
+  position: relative;
+
+  #index-header-background {
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+
+    width: 100%;
+    height: 100%;
+    z-index: -30;
+
+    background-color: #6df2c7;
+    @include gradient-directional($start-color: #8df472, $end-color: #6df2c7);
+    clip-path: polygon(0 0, 100% 0%, 50% 100%, 0% 100%);
+  }
+}
+
 // First block on homepage
 div.area-index-header {
   padding-top: 0;
@@ -63,26 +83,8 @@ div.area-index-header {
       line-height: 1.5;
 
       span {
-        padding: {
-          left: 7px;
-          right: 7px;
-          top: 3px;
-          bottom: 3px;
-        }
-
-        margin-left: -4px;
-      }
-
-      span.hl-1 {
-        background: #8df472;
-      }
-
-      span.hl-2 {
-        background: #8ee3fc;
-      }
-
-      span.hl-3 {
-        background: #b6adf9;
+        text-decoration: underline;
+        text-decoration-color: rgba(56, 56, 56, 0.4);
       }
     }
   }
@@ -106,14 +108,13 @@ div.area-index-header {
     text-align: center;
 
     td {
-      border: 2px solid white;
+      border: 2px solid rgba(255, 255, 255, 0.8);
       width: 70px;
     }
 
     .time-left-numbers td {
-      font-family: 'Courier New', monospace;
       font-size: 200%;
-      font-weight: bold;
+      font-weight: 700;
     }
   }
 }

--- a/static-dev/sass/main.scss
+++ b/static-dev/sass/main.scss
@@ -83,11 +83,7 @@ div.area {
 
 @import 'head';
 
-div.area-2 {
-  @include gradient-directional($start-color: #8df472, $end-color: #6df2c7);
-}
-
-div.area-4 {
+div.area-2, div.area-4 {
   @include gradient-directional($start-color: #8ee3fc, $end-color: #ab9ffc);
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,33 +23,35 @@
 			<p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="https://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
 		<![endif]-->
 
-		<div class="container-fluid header-nav">
-			<nav class="navbar navbar-toggleable-md navbar-light">
-				<button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#header-nav-sub" aria-controls="header-nav-sub" aria-expanded="false" aria-label="Toggle navigation">
-					<span class="navbar-toggler-icon"></span>
-				</button>
-				<a class="navbar-brand" href="/">#copyfighters</a>
-				<span class="navbar-text">Fighting for our Digital Rights in Europe</span>
-				{% block navlinks %}
-				<div class="collapse navbar-collapse" id="header-nav-sub">
-					<ul class="navbar-nav mr-auto">
-						<li class="nav-item active">
-							<a class="nav-link" href="/">Home <span class="sr-only">(current)</span></a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="{% url 'resources' %}">Resources</a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="{% url 'imprint' %}">Imprint</a>
-						</li>
-						<li class="nav-item">
-							<a class="nav-link" href="{% url 'privacy' %}">Privacy</a>
-						</li>
-					</ul>
-				</div>
-				{% endblock %}
-			</nav>
-		</div>
+		{% block navigation %}
+			<div class="container-fluid header-nav">
+				<nav class="navbar navbar-toggleable-md navbar-light">
+					<button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#header-nav-sub" aria-controls="header-nav-sub" aria-expanded="false" aria-label="Toggle navigation">
+						<span class="navbar-toggler-icon"></span>
+					</button>
+					<a class="navbar-brand" href="/">#copyfighters</a>
+					<span class="navbar-text">Fighting for our Digital Rights in Europe</span>
+					{% block navlinks %}
+					<div class="collapse navbar-collapse" id="header-nav-sub">
+						<ul class="navbar-nav mr-auto">
+							<li class="nav-item active">
+								<a class="nav-link" href="/">Home <span class="sr-only">(current)</span></a>
+							</li>
+							<li class="nav-item">
+								<a class="nav-link" href="{% url 'resources' %}">Resources</a>
+							</li>
+							<li class="nav-item">
+								<a class="nav-link" href="{% url 'imprint' %}">Imprint</a>
+							</li>
+							<li class="nav-item">
+								<a class="nav-link" href="{% url 'privacy' %}">Privacy</a>
+							</li>
+						</ul>
+					</div>
+					{% endblock %}
+				</nav>
+			</div>
+		{% endblock navigation %}
 
 		{% block content %}{% endblock %}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,14 @@
 {% load staticfiles %}
 {% load i18n %}
 
+
+{% block navigation %}
+	{# This block is closed again in the content block. It is used to place the background spanning the navigation and first content block. #}
+	<div id="index-background-container">
+		<div id="index-header-background">&nbsp;</div>
+		{{ block.super }}
+{% endblock %}
+
 {% block navlinks %}{% endblock %}
 
 {% block content %}
@@ -9,7 +17,7 @@
 		<div class="row justify-content-center area area-index-header">
 			<div class="col">
 				<h1 id="main-title">
-					<span id="main-title-strings"><p>{% blocktrans %}We want a Europe where <span class="hl-1">sharing</span>, <span class="hl-2">innovation</span> and <span class="hl-3">copyright</span> go hand in hand.{% endblocktrans %}</p></span>
+					<span id="main-title-strings"><p>{% blocktrans %}We want a Europe where <span>sharing</span>, <span>innovation</span> and <span>copyright</span> go hand in hand.{% endblocktrans %}</p></span>
 					<span id="main-title-container"></span>
 				</h1>
 			</div>
@@ -53,6 +61,9 @@
 				</form>
 			</div>
 		</div>
+	</div>
+
+	{# This closes the div opened in the navigation block #}
 	</div>
 
 	{% comment %}


### PR DESCRIPTION
![2017-08-06-00 03 02](https://user-images.githubusercontent.com/179393/28999065-a63be59a-7a3a-11e7-8390-972b27bc9f4b.png)

Due to all the text, the colorful stuff below isn't visible on smaller screen sizes, making the whole thing look very bland and black/white. This is to combat that. I removed the colorful highlights in the main headline, because with them the whole thing becomes way to colorful.