### PR TITLE
Make title highlights bold instead of underlined

### DIFF
--- a/static-dev/sass/_head.scss
+++ b/static-dev/sass/_head.scss
@@ -100,7 +100,7 @@ div.area-index-header {
       line-height: 1.5;
 
       span {
-        text-decoration: underline;
+        font-weight: 900;
         text-decoration-color: rgba(56, 56, 56, 0.4);
       }
     }


### PR DESCRIPTION
As underlined words suggest links in the WWW, I suggest making these words bold instead.

![bold](https://user-images.githubusercontent.com/12501775/29006479-2d4c03d8-7af1-11e7-8d71-21d1fd9776c3.png)
