### PR TITLE
Hide e-mail form & show call MEP hint instead

### DIFF
--- a/static-dev/sass/main.scss
+++ b/static-dev/sass/main.scss
@@ -284,13 +284,11 @@ div.area-email {
         border-radius: 0;
         color: #fff;
         flex: 1 1 100%;
-
         font: {
           family: $main-font;
           size: 1.6rem;
           weight: 200;
         }
-
         text-decoration: underline rgba(255, 255, 255, 0.3);
 
         @include placeholder {
@@ -361,6 +359,48 @@ div.area-email {
             left: 10px;
             right: 12px;
           }
+        }
+      }
+    }
+
+    .call-mep {
+      align-items: center;
+      display: flex;
+      flex-direction: row;
+      padding: 4px 0;
+      width: 100%;
+
+      .call-text {
+        background-color: #000;
+        border: 0;
+        border-radius: 0;
+        color: #fff;
+        flex: 1 1 100%;
+        font: {
+          family: $main-font;
+          size: 1.6rem;
+          weight: 200;
+        }
+      }
+
+      .call-button {
+        background: transparent;
+        border: 1px solid #fff;
+        color: #fff;
+        flex-shrink: 0;
+        font: {
+          family: $main-font;
+          size: 1.3rem;
+          weight: 700;
+        }
+        line-height: .8;
+        min-width: 0;
+        padding: 8px 10px;
+
+        &:active,
+        &:focus,
+        &:hover {
+          text-decoration: none;
         }
       }
     }

--- a/templates/index.html
+++ b/templates/index.html
@@ -49,7 +49,7 @@
 	<div class="container-fluid area area-email">
 		<div class="row">
 			<div class="col-xs-12">
-				<form class="email_form" action="/email_form/" method="post">
+				<form class="email_form" action="/email_form/" method="post" style="display: none;">
 					<p class="form_status"></p>
 					{% csrf_token %}
 					{{ email_form }}
@@ -57,6 +57,10 @@
 					<span id="email_reload">&#8635;</span>
 					<p id="email_share">{% blocktrans %}Share on <span id="share_fb"><i class="fa fa-facebook" aria-hidden="true"></i> Facebook</span> or <span id="share_twitter"><i class="fa fa-twitter" aria-hidden="true"></i> Twitter</span>{% endblocktrans %}</p>
 				</form>
+				<div class="call-mep">
+					<span class="call-text">{% trans 'Call a Member of the European Parliament via Mozilla!' %}</span>
+					<a class="call-button" href="https://changecopyright.org" target="_blank">{% trans 'Call now' %}</a>
+				</div>
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
As long as we have no newsletter team set up, we should not collect e-mail addresses. I have simply hidden the form. As I really like the black bar, you are asked to call your MEP instead.